### PR TITLE
Update ContractParser.version

### DIFF
--- a/GameData/DMagicUtilities/ContractParser/ContractParser.version
+++ b/GameData/DMagicUtilities/ContractParser/ContractParser.version
@@ -25,7 +25,7 @@
      },
      "KSP_VERSION_MAX":{
          "MAJOR":1,
-         "MINOR":8,
+         "MINOR":12,
          "PATCH":8
      }
  } 


### PR DESCRIPTION
Updated max version to 1.12.8

It seems to work ok with 1.12, I did a test recompile against the 1.12.3 files and it was a clean compile.

This is needed so that it will be available in CKAN for those mods which depend on it